### PR TITLE
Enh/add validation

### DIFF
--- a/brood_diff/diff.py
+++ b/brood_diff/diff.py
@@ -92,14 +92,14 @@ def cli_get_index(url, repository, platform, version, output, sort, legacy):
 @click.option('--url', '-u', type=str,
               help="<EDS URL> Must include http or https as needed")
 @click.option('--repository', '-r', multiple=True, type=str,
-              callback=valid.validate_org_repo,
+              callback=valid.validate_org_repos,
               help=("<org/repo> Must be in EDS/Hatcher format: `org/repo`"
                     "\ne.g. enthought/free"))
 @click.option('--platform', '-p', multiple=True, type=str,
-              callback=valid.validate_platform,
+              callback=valid.validate_platforms,
               help="<platform> See list-platforms for supported platforms")
 @click.option('--version', '-v', multiple=True, type=str,
-              callback=valid.validate_version,
+              callback=valid.validate_versions,
               help=("<python-version> See list-versions for "
                     "supported python version tags"))
 @click.option('--output', '-o', type=str,
@@ -164,14 +164,14 @@ def cli_gen_diff(local, remote, output):
 @click.option('--local', '-l', type=str,
               help="<path> Full path to json file for local index")
 @click.option('--repository', '-r', multiple=True, type=str,
-              callback=valid.validate_org_repo,
+              callback=valid.validate_org_repos,
               help=("<org/repo> Must be in EDS/Hatcher format: `org/repo`"
                     "\ne.g. enthought/free"))
 @click.option('--platform', '-p', multiple=True, type=str,
-              callback=valid.validate_platform,
+              callback=valid.validate_platforms,
               help="<platform> See list-platforms for supported platforms")
 @click.option('--version', '-v', multiple=True, type=str,
-              callback=valid.validate_version,
+              callback=valid.validate_versions,
               help=("<python-version> See list-versions for "
                     "supported python version tags"))
 @click.option('--output', '-o', type=str,

--- a/brood_diff/diff.py
+++ b/brood_diff/diff.py
@@ -54,12 +54,12 @@ def cli():
 @cli.command(name="get-index")
 @click.option('--url', '-u', type=str,
               help="<EDS URL> Must include http or https as needed")
-@click.option('--repository', '-r', type=str,
+@click.option('--repository', '-r', type=str, callback=valid.validate_org_repo,
               help=("<org/repo> Must be in EDS/Hatcher format: `org/repo`"
                     "\ne.g. enthought/free"))
-@click.option('--platform', '-p', type=str,
+@click.option('--platform', '-p', type=str, callback=valid.validate_platform,
               help="<platform> See list-platforms for supported platforms")
-@click.option('--version', '-v', type=str,
+@click.option('--version', '-v', type=str, callback=valid.validate_version,
               help=("<python-version> See list-versions for "
                     "supported python version tags"))
 @click.option('--output', '-o', type=str,
@@ -75,21 +75,10 @@ def cli_get_index(url, repository, platform, version, output, sort, legacy):
     """ Get index for a given repo/platform/python-tag from EDS instance
     located at url specified by -u/--url and write output to file
     specified by -o/--output."""
-    if valid.validate_org_repo(repository):
-        org, repo = repository.split("/")
-    else:
-        click.echo("Repository must be in format `org/repo`")
-        return
-    if not valid.validate_platform(platform):
-        click.secho("Invalid platform specification: {}".format(platform),
-                    fg='red')
-        click.echo("For a list of valid platforms: diff.py list-platforms.")
-        return
-    if not valid.validate_version(version):
-        click.secho("Invalid version specification: {}".format(version),
-                    fg='red')
-        click.echo("For a list of valid versions: diff.py list-versions.")
-        return
+
+    org, repo = valid.validate_org_repo(repository).split("/")
+    platform = valid.validate_platform(platform)
+    version = valid.validate_version(version)
 
     idx = get_index(url,
                     org,

--- a/brood_diff/diff.py
+++ b/brood_diff/diff.py
@@ -76,9 +76,7 @@ def cli_get_index(url, repository, platform, version, output, sort, legacy):
     located at url specified by -u/--url and write output to file
     specified by -o/--output."""
 
-    org, repo = valid.validate_org_repo(repository).split("/")
-    platform = valid.validate_platform(platform)
-    version = valid.validate_version(version)
+    org, repo = repository.split("/")
 
     idx = get_index(url,
                     org,
@@ -94,11 +92,14 @@ def cli_get_index(url, repository, platform, version, output, sort, legacy):
 @click.option('--url', '-u', type=str,
               help="<EDS URL> Must include http or https as needed")
 @click.option('--repository', '-r', multiple=True, type=str,
+              callback=valid.validate_org_repo,
               help=("<org/repo> Must be in EDS/Hatcher format: `org/repo`"
                     "\ne.g. enthought/free"))
 @click.option('--platform', '-p', multiple=True, type=str,
+              callback=valid.validate_platform,
               help="<platform> See list-platforms for supported platforms")
 @click.option('--version', '-v', multiple=True, type=str,
+              callback=valid.validate_version,
               help=("<python-version> See list-versions for "
                     "supported python version tags"))
 @click.option('--output', '-o', type=str,
@@ -116,6 +117,7 @@ def cli_get_full_index(url, repository, platform, version, output, sort,
     instance specified by -u/--url for potentially multiple platforms,
     repositories, and python versions, and output the full index as a single
     json file specified by -o/--output."""
+
     gen_full_index(url,
                    repository,
                    platform,
@@ -162,11 +164,14 @@ def cli_gen_diff(local, remote, output):
 @click.option('--local', '-l', type=str,
               help="<path> Full path to json file for local index")
 @click.option('--repository', '-r', multiple=True, type=str,
+              callback=valid.validate_org_repo,
               help=("<org/repo> Must be in EDS/Hatcher format: `org/repo`"
                     "\ne.g. enthought/free"))
 @click.option('--platform', '-p', multiple=True, type=str,
+              callback=valid.validate_platform,
               help="<platform> See list-platforms for supported platforms")
 @click.option('--version', '-v', multiple=True, type=str,
+              callback=valid.validate_version,
               help=("<python-version> See list-versions for "
                     "supported python version tags"))
 @click.option('--output', '-o', type=str,

--- a/brood_diff/tests/test_cli_validation.py
+++ b/brood_diff/tests/test_cli_validation.py
@@ -10,6 +10,23 @@ from brood_diff import valid
 class TestValidation(object):
     """ Testing of CLI option validation."""
 
+    def test_validate_platforms(self):
+        good_plats = ("osx-x86_64", "rh6-x86_64", "win-x86_64")
+        bad_plats = ("osx-x87_64", "rh6-x86_64", "win-x86_64")
+        ctx = None
+        param = None
+
+        # when
+        g_plats = valid.validate_platforms(ctx, param, good_plats)
+
+        with pytest.raises(click.BadParameter) as execinfo:
+            valid.validate_platforms(ctx, param, bad_plats)
+
+        # then
+        assert g_plats == good_plats
+        assert "Invalid platform(s)" in str(execinfo.value)
+        assert "osx-x87_64" in str(execinfo.value)
+
     def test_validate_platform(self):
         # given
         good_plat = "osx-x86_64"
@@ -27,6 +44,24 @@ class TestValidation(object):
         assert g_plat == good_plat
         assert "Invalid platform" in str(execinfo.value)
 
+    def test_validate_versions(self):
+        # given
+        good_vers = ("cp36", "cp35", "cp27")
+        bad_vers = ("cp16", "cp35", "cp27")
+        ctx = None
+        param = None
+
+        # when
+        g_vers = valid.validate_versions(ctx, param, good_vers)
+
+        with pytest.raises(click.BadParameter) as execinfo:
+            valid.validate_versions(ctx, param, bad_vers)
+
+        # then
+        assert g_vers == good_vers
+        assert "Invalid python version(s)" in str(execinfo.value)
+        assert "cp16" in str(execinfo.value)
+
     def test_validate_version(self):
         # given
         good_vers = "cp36"
@@ -43,6 +78,24 @@ class TestValidation(object):
         # then
         assert g_vers == good_vers
         assert "Invalid python version" in str(execinfo.value)
+
+    def test_validate_repositories(self):
+        # given
+        good_repos = ("enthought/free", "enthought/gpl", "an_org/a_repo")
+        bad_repos = ("enthought free",  "enthought/gpl", "an_org/a_repo")
+        ctx = None
+        param = None
+
+        # when
+        g_repos = valid.validate_org_repos(ctx, param, good_repos)
+
+        with pytest.raises(click.BadParameter) as execinfo:
+            valid.validate_org_repos(ctx, param, bad_repos)
+
+        # then
+        assert g_repos == good_repos
+        assert "Invalid repository" in str(execinfo.value)
+        assert "enthought free" in str(execinfo.value)
 
     def test_validate_repository(self):
         # given

--- a/brood_diff/tests/test_cli_validation.py
+++ b/brood_diff/tests/test_cli_validation.py
@@ -15,12 +15,13 @@ class TestValidation(object):
         good_plat = "osx-x86_64"
         bad_plat = "osx-x87_64"
         ctx = None
+        param = None
 
         # when
-        g_plat = valid.validate_platform(ctx, good_plat)
+        g_plat = valid.validate_platform(ctx, param, good_plat)
 
         with pytest.raises(click.BadParameter) as execinfo:
-            valid.validate_platform(ctx, bad_plat)
+            valid.validate_platform(ctx, param, bad_plat)
 
         # then
         assert g_plat == good_plat
@@ -31,12 +32,13 @@ class TestValidation(object):
         good_vers = "cp36"
         bad_vers = "cp16"
         ctx = None
+        param = None
 
         # when
-        g_vers = valid.validate_version(ctx, good_vers)
+        g_vers = valid.validate_version(ctx, param, good_vers)
 
         with pytest.raises(click.BadParameter) as execinfo:
-            valid.validate_version(ctx, bad_vers)
+            valid.validate_version(ctx, param, bad_vers)
 
         # then
         assert g_vers == good_vers
@@ -47,12 +49,13 @@ class TestValidation(object):
         good_repo = "enthought/free"
         bad_repo = "enthought free"
         ctx = None
+        param = None
 
         # when
-        g_repo = valid.validate_org_repo(ctx, good_repo)
+        g_repo = valid.validate_org_repo(ctx, param, good_repo)
 
         with pytest.raises(click.BadParameter) as execinfo:
-            valid.validate_org_repo(ctx, bad_repo)
+            valid.validate_org_repo(ctx, param, bad_repo)
 
         # then
         assert g_repo == good_repo

--- a/brood_diff/tests/test_cli_validation.py
+++ b/brood_diff/tests/test_cli_validation.py
@@ -21,8 +21,39 @@ class TestValidation(object):
 
         with pytest.raises(click.BadParameter) as execinfo:
             valid.validate_platform(ctx, bad_plat)
-        
+
         # then
         assert g_plat == good_plat
         assert "Invalid platform" in str(execinfo.value)
-        
+
+    def test_validate_version(self):
+        # given
+        good_vers = "cp36"
+        bad_vers = "cp16"
+        ctx = None
+
+        # when
+        g_vers = valid.validate_version(ctx, good_vers)
+
+        with pytest.raises(click.BadParameter) as execinfo:
+            valid.validate_version(ctx, bad_vers)
+
+        # then
+        assert g_vers == good_vers
+        assert "Invalid python version" in str(execinfo.value)
+
+    def test_validate_repository(self):
+        # given
+        good_repo = "enthought/free"
+        bad_repo = "enthought free"
+        ctx = None
+
+        # when
+        g_repo = valid.validate_org_repo(ctx, good_repo)
+
+        with pytest.raises(click.BadParameter) as execinfo:
+            valid.validate_org_repo(ctx, bad_repo)
+
+        # then
+        assert g_repo == good_repo
+        assert "Invalid repository" in str(execinfo.value)

--- a/brood_diff/tests/test_cli_validation.py
+++ b/brood_diff/tests/test_cli_validation.py
@@ -1,0 +1,28 @@
+# (C) Copyright 2018 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+import click
+import pytest
+
+from brood_diff import valid
+
+
+class TestValidation(object):
+    """ Testing of CLI option validation."""
+
+    def test_validate_platform(self):
+        # given
+        good_plat = "osx-x86_64"
+        bad_plat = "osx-x87_64"
+        ctx = None
+
+        # when
+        g_plat = valid.validate_platform(ctx, good_plat)
+
+        with pytest.raises(click.BadParameter) as execinfo:
+            valid.validate_platform(ctx, bad_plat)
+        
+        # then
+        assert g_plat == good_plat
+        assert "Invalid platform" in str(execinfo.value)
+        

--- a/brood_diff/valid.py
+++ b/brood_diff/valid.py
@@ -39,7 +39,7 @@ def validate_version(ctx: click.Context, ver: str):
         return ver
     else:
         raise click.BadParameter(
-            ("Invalid python versions {}. Please use list-platforms for a list"
+            ("Invalid python version {}. Please use list-platforms for a list"
              " of supported platforms.".format(ver)))
 
 

--- a/brood_diff/valid.py
+++ b/brood_diff/valid.py
@@ -2,6 +2,8 @@
 # All rights reserved.
 #
 
+import click
+
 
 PLATS = ["osx-x86",
          "rh5-x86",
@@ -21,16 +23,32 @@ VERS = ["cp27",
         "pp27"]
 
 
-def validate_platform(plat: str):
+def validate_platform(ctx: click.Context, plat: str):
     """ Validate User CLI input."""
-    return plat in PLATS
+    if plat in PLATS:
+        return plat
+    else:
+        raise click.BadParameter(
+            ("Invalid platform {}. Please use list-platforms for a list of"
+             " supported platforms.".format(plat)))
 
 
-def validate_version(ver: str):
+def validate_version(ctx: click.Context, ver: str):
     """ Validate User CLI input."""
-    return ver in VERS
+    if ver in VERS:
+        return ver
+    else:
+        raise click.BadParameter(
+            ("Invalid python versions {}. Please use list-platforms for a list"
+             " of supported platforms.".format(ver)))
 
 
-def validate_org_repo(org_repo: str):
+def validate_org_repo(ctx: click.Context, org_repo: str):
     """ Validate User CLI input."""
-    return "/" in org_repo and len(org_repo.split("/")) == 2
+    if "/" in org_repo and len(org_repo.split("/")) == 2:
+        return org_repo
+    else:
+        raise click.BadParameter(
+            ("Invalid repository format {}. Repositories must use the"
+             " EDS/Hatcher format <org/repo>."
+             "e.g. enthought/free".format(org_repo)))

--- a/brood_diff/valid.py
+++ b/brood_diff/valid.py
@@ -29,7 +29,7 @@ def validate_platform(ctx: click.Context, plat: str):
         return plat
     else:
         raise click.BadParameter(
-            ("Invalid platform {}. Please use list-platforms for a list of"
+            ("Invalid platform: {}. Please use list-platforms for a list of"
              " supported platforms.".format(plat)))
 
 
@@ -39,16 +39,19 @@ def validate_version(ctx: click.Context, ver: str):
         return ver
     else:
         raise click.BadParameter(
-            ("Invalid python version {}. Please use list-platforms for a list"
+            ("Invalid python version: {}. Please use list-platforms for a list"
              " of supported platforms.".format(ver)))
 
 
 def validate_org_repo(ctx: click.Context, org_repo: str):
-    """ Validate User CLI input."""
+    """ Validate User CLI input.
+    Repositories are formatted using the EDS/Hatcher format <org/repo> - e.g.
+        enthought/free
+    """
     if "/" in org_repo and len(org_repo.split("/")) == 2:
         return org_repo
     else:
         raise click.BadParameter(
-            ("Invalid repository format {}. Repositories must use the"
+            ("Invalid repository format: {}. Repositories must use the"
              " EDS/Hatcher format <org/repo>."
              "e.g. enthought/free".format(org_repo)))

--- a/brood_diff/valid.py
+++ b/brood_diff/valid.py
@@ -23,35 +23,41 @@ VERS = ["cp27",
         "pp27"]
 
 
-def validate_platform(ctx: click.Context, plat: str):
+def validate_platform(ctx: click.Context,
+                      param: click.core.Option,
+                      value: str):
     """ Validate User CLI input."""
-    if plat in PLATS:
-        return plat
+    if value in PLATS:
+        return value
     else:
         raise click.BadParameter(
             ("Invalid platform: {}. Please use list-platforms for a list of"
-             " supported platforms.".format(plat)))
+             " supported platforms.".format(value)))
 
 
-def validate_version(ctx: click.Context, ver: str):
+def validate_version(ctx: click.Context,
+                     param: click.core.Option,
+                     value: str):
     """ Validate User CLI input."""
-    if ver in VERS:
-        return ver
+    if value in VERS:
+        return value
     else:
         raise click.BadParameter(
             ("Invalid python version: {}. Please use list-platforms for a list"
-             " of supported platforms.".format(ver)))
+             " of supported platforms.".format(value)))
 
 
-def validate_org_repo(ctx: click.Context, org_repo: str):
+def validate_org_repo(ctx: click.Context,
+                      param: click.core.Option,
+                      value: str):
     """ Validate User CLI input.
     Repositories are formatted using the EDS/Hatcher format <org/repo> - e.g.
         enthought/free
     """
-    if "/" in org_repo and len(org_repo.split("/")) == 2:
-        return org_repo
+    if "/" in value and len(value.split("/")) == 2:
+        return value
     else:
         raise click.BadParameter(
             ("Invalid repository format: {}. Repositories must use the"
              " EDS/Hatcher format <org/repo>."
-             "e.g. enthought/free".format(org_repo)))
+             "e.g. enthought/free".format(value)))

--- a/brood_diff/valid.py
+++ b/brood_diff/valid.py
@@ -23,16 +23,44 @@ VERS = ["cp27",
         "pp27"]
 
 
+def validate_platforms(ctx: click.Context,
+                       param: click.core.Option,
+                       value: tuple):
+    """ Validate User CLI input for multiple values."""
+    sv = set(value)
+    sp = set(PLATS)
+    if sv <= sp:
+        return value
+    else:
+        raise click.BadParameter(
+            ("Invalid platform(s): {}. Please use list-platforms for a list of"
+             " supported platforms.".format(sv - sp)))
+
+
 def validate_platform(ctx: click.Context,
                       param: click.core.Option,
                       value: str):
-    """ Validate User CLI input."""
+    """ Validate User CLI input for single value."""
     if value in PLATS:
         return value
     else:
         raise click.BadParameter(
             ("Invalid platform: {}. Please use list-platforms for a list of"
              " supported platforms.".format(value)))
+
+
+def validate_versions(ctx: click.Context,
+                      param: click.core.Option,
+                      value: tuple):
+    """ Validate User CLI input for multiple values."""
+    sv = set(value)
+    spv = set(VERS)
+    if sv <= spv:
+        return value
+    else:
+        raise click.BadParameter(
+            ("Invalid python version(s): {}. Please use list-versions for a"
+             " list of supported versions.".format(sv - spv)))
 
 
 def validate_version(ctx: click.Context,
@@ -43,8 +71,23 @@ def validate_version(ctx: click.Context,
         return value
     else:
         raise click.BadParameter(
-            ("Invalid python version: {}. Please use list-platforms for a list"
-             " of supported platforms.".format(value)))
+            ("Invalid python version: {}. Please use list-versions for a list"
+             " of supported versions.".format(value)))
+
+
+def validate_org_repos(ctx: click.Context,
+                       param: click.core.Option,
+                       value: tuple):
+    """ Validate User CLI input for multiple values."""
+    for org_repo in value:
+        if "/" in org_repo and len(org_repo.split("/")) == 2:
+            continue
+        else:
+            raise click.BadParameter(
+                ("Invalid repository format: {}. Repositories must use the"
+                 " EDS/Hatcher format <org/repo>."
+                 " e.g. enthought/free".format(org_repo)))
+    return value
 
 
 def validate_org_repo(ctx: click.Context,


### PR DESCRIPTION
This PR changes the way that the validation for CLI user input occurs and uses the click option callback mechanism for validation.

Additionally, validation is extended to all CLI methods that require user input for repo, python version, and platform.